### PR TITLE
Upgrade dependencies and re-generate chain types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "litentry-squid",
   "private": true,
   "devDependencies": {
-    "@subsquid/cli": "^0.1.1",
+    "@subsquid/cli": "^0.1.4",
     "@subsquid/substrate-metadata-explorer": "^0.0.7",
     "@subsquid/substrate-typegen": "^0.2.3",
     "@types/node": "^16.11.17",

--- a/prawns/balances/package.json
+++ b/prawns/balances/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@polkadot/util-crypto": "^8.4.1",
-    "@subsquid/graphql-server": "^0.1.4",
-    "@subsquid/ss58": "^0.0.3",
-    "@subsquid/substrate-processor": "^0.3.0",
+    "@subsquid/graphql-server": "^0.1.5",
+    "@subsquid/ss58": "^0.0.4",
+    "@subsquid/substrate-processor": "^0.4.1",
     "dotenv": "^10.0.0",
     "pg": "^8.7.1",
     "typeorm": "^0.2.41"

--- a/prawns/balances/src/handlers/typeGetters/getTreasuryEvents.ts
+++ b/prawns/balances/src/handlers/typeGetters/getTreasuryEvents.ts
@@ -25,7 +25,7 @@ export function getTreasuryDepositEvent(
       if (event.isV0) {
         return event.asV0;
       } else {
-        return event.asLatest;
+        return event.asV9170.value;
       }
     }
 
@@ -35,7 +35,7 @@ export function getTreasuryDepositEvent(
       if (event.isV1020) {
         return event.asV1020;
       } else {
-        return event.asLatest;
+        return event.asV9160.value;
       }
     }
 

--- a/prawns/balances/src/types/khala/events.ts
+++ b/prawns/balances/src/types/khala/events.ts
@@ -12,7 +12,7 @@ export class BalancesBalanceSetEvent {
    *  A balance was set by root. \[who, free, reserved\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '890be9c0740650f86b325a08fc07ecc4c2b4f58212c6edaca87dabdbb64d3db1'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '0f263bfdefa394edfb38d20d33662423a2e0902235b599f9b2b0292f157f0902'
   }
 
   /**
@@ -27,7 +27,7 @@ export class BalancesBalanceSetEvent {
    * A balance was set by root.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '4ab45d6d95726adfeb725535bf55a2406d3b4d8ae14ac9005c7bd7e07ea76fcc'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '1e2b5d5a07046e6d6e5507661d3f3feaddfb41fc609a2336b24957322080ca77'
   }
 
   /**
@@ -58,7 +58,7 @@ export class BalancesDepositEvent {
    *  Some amount was deposited (e.g. for transaction fees). \[who, deposit\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === 'cf0c633b4d95aa1626767eef7c869b6d51b4e864772aceeb18ec2d4ebd8a9101'
+    return this.ctx._chain.getEventHash('balances.Deposit') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -73,7 +73,7 @@ export class BalancesDepositEvent {
    * Some amount was deposited (e.g. for transaction fees).
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === '3e10f037979c6bc49d783be86e7fa6eb9642f270ffedf3352fae03a41fcf22e4'
+    return this.ctx._chain.getEventHash('balances.Deposit') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -105,7 +105,7 @@ export class BalancesDustLostEvent {
    *  resulting in an outright loss. \[account, balance\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === 'cc03bf0e885d06ab5165f4598e72250fd3e16bc5ba4dbb099deae1a97e4bef09'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -122,7 +122,7 @@ export class BalancesDustLostEvent {
    * resulting in an outright loss.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === '10bbf3b0d3ec83ccf1a23f056e1a60d4f66be59072296b48ebf9172ffcdab3f6'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '504f155afb2789c50df19d1f747fb2dc0e99bf8b7623c30bdb5cf82029fec760'
   }
 
   /**
@@ -154,7 +154,7 @@ export class BalancesEndowedEvent {
    *  An account was created with some free balance. \[account, free_balance\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '1b1c107d9931735af253054e543179401a9ff7b0beaee7fa7aa61319dc40a290'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -169,7 +169,7 @@ export class BalancesEndowedEvent {
    * An account was created with some free balance.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '089e94580955109582764033c0ac689ca378b9d2d399441102b094e72be986e7'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '75951f685df19cbb5fdda09cf928a105518ceca9576d95bd18d4fac8802730ca'
   }
 
   /**
@@ -202,7 +202,7 @@ export class BalancesReserveRepatriatedEvent {
    *  \[from, to, balance, destination_status\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '823db0df51a00ee6479e9d206981c4cb7b4afcdfb66f2b1626a9c053026a511e'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '68e9ec5664c8ffe977da0c890bac43122a5cf13565c1c936e2120ba4980bcf31'
   }
 
   /**
@@ -220,7 +220,7 @@ export class BalancesReserveRepatriatedEvent {
    * Final argument indicates the destination balance type.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '1dac0fc1bd585ad6dd890e892bed23d70ca0545bf18fa96b4ce0ba7f3ffcdbd1'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '6232d50d422cea3a6fd21da36387df36d1d366405d0c589566c6de85c9cf541f'
   }
 
   /**
@@ -252,7 +252,7 @@ export class BalancesReservedEvent {
    *  Some balance was reserved (moved from free to reserved). \[who, value\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'c595c2f71b423f0c1e0798ad69320278f19e727a480f58f312a585980145cf22'
+    return this.ctx._chain.getEventHash('balances.Reserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -267,7 +267,7 @@ export class BalancesReservedEvent {
    * Some balance was reserved (moved from free to reserved).
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'bc321147cc9b824c85c432ac3c753b1319c9ad37babdd0e09ae0f99aeecc9360'
+    return this.ctx._chain.getEventHash('balances.Reserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -298,7 +298,7 @@ export class BalancesSlashedEvent {
    * Some amount was removed from the account (e.g. for misbehavior).
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Slashed') === '087119b0d937e152a3831b84db573c85f89c84a6fd587673ee923c9f0061ed66'
+    return this.ctx._chain.getEventHash('balances.Slashed') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -329,7 +329,7 @@ export class BalancesTransferEvent {
    *  Transfer succeeded. \[from, to, value\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '9611bd6b933331f197e8fa73bac36184681838292120987fec97092ae037d1c8'
+    return this.ctx._chain.getEventHash('balances.Transfer') === 'dad2bcdca357505fa3c7832085d0db53ce6f902bd9f5b52823ee8791d351872c'
   }
 
   /**
@@ -344,7 +344,7 @@ export class BalancesTransferEvent {
    * Transfer succeeded.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '99bc4786247456e0d4a44373efe405e598bfadfac87a7c41b0a82a91296836c1'
+    return this.ctx._chain.getEventHash('balances.Transfer') === '0ffdf35c495114c2d42a8bf6c241483fd5334ca0198662e14480ad040f1e3a66'
   }
 
   /**
@@ -375,7 +375,7 @@ export class BalancesUnreservedEvent {
    *  Some balance was unreserved (moved from reserved to free). \[who, value\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'ab01310b8e7de989b74305e42be550e888c6563ed4ea284f7c56ae7d79566f8c'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -390,7 +390,7 @@ export class BalancesUnreservedEvent {
    * Some balance was unreserved (moved from reserved to free).
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'be12b7473ab82e15891b929b20269451c731ffad981836a76ca0aae115b9e9f6'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -421,7 +421,7 @@ export class BalancesWithdrawEvent {
    * Some amount was withdrawn from the account (e.g. for transaction fees).
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('balances.Withdraw') === '7d47465a5bcac497a2c0e813fe27069aff5d6086a74365c4f40bc0d5332e1356'
+    return this.ctx._chain.getEventHash('balances.Withdraw') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -452,7 +452,7 @@ export class TreasuryDepositEvent {
    *  Some funds have been deposited. \[deposit\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('treasury.Deposit') === '00a6b2996298e567aad20092952a8a74feec74cde3e7a57572700c49512f941d'
+    return this.ctx._chain.getEventHash('treasury.Deposit') === '47b59f698451e50cce59979f0121e842fa3f8b2bcef2e388222dbd69849514f9'
   }
 
   /**

--- a/prawns/balances/src/types/kusama/events.ts
+++ b/prawns/balances/src/types/kusama/events.ts
@@ -13,7 +13,7 @@ export class BalancesBalanceSetEvent {
    *  A balance was set by root (who, free, reserved).
    */
   get isV1031(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '890be9c0740650f86b325a08fc07ecc4c2b4f58212c6edaca87dabdbb64d3db1'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '0f263bfdefa394edfb38d20d33662423a2e0902235b599f9b2b0292f157f0902'
   }
 
   /**
@@ -28,7 +28,7 @@ export class BalancesBalanceSetEvent {
    * A balance was set by root.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '4ab45d6d95726adfeb725535bf55a2406d3b4d8ae14ac9005c7bd7e07ea76fcc'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '1e2b5d5a07046e6d6e5507661d3f3feaddfb41fc609a2336b24957322080ca77'
   }
 
   /**
@@ -59,7 +59,7 @@ export class BalancesDepositEvent {
    *  Some amount was deposited (e.g. for transaction fees).
    */
   get isV1032(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === 'cf0c633b4d95aa1626767eef7c869b6d51b4e864772aceeb18ec2d4ebd8a9101'
+    return this.ctx._chain.getEventHash('balances.Deposit') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -74,7 +74,7 @@ export class BalancesDepositEvent {
    * Some amount was deposited (e.g. for transaction fees).
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === '3e10f037979c6bc49d783be86e7fa6eb9642f270ffedf3352fae03a41fcf22e4'
+    return this.ctx._chain.getEventHash('balances.Deposit') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -106,7 +106,7 @@ export class BalancesDustLostEvent {
    *  resulting in an outright loss.
    */
   get isV1050(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === 'cc03bf0e885d06ab5165f4598e72250fd3e16bc5ba4dbb099deae1a97e4bef09'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -123,7 +123,7 @@ export class BalancesDustLostEvent {
    * resulting in an outright loss.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === '10bbf3b0d3ec83ccf1a23f056e1a60d4f66be59072296b48ebf9172ffcdab3f6'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '504f155afb2789c50df19d1f747fb2dc0e99bf8b7623c30bdb5cf82029fec760'
   }
 
   /**
@@ -155,7 +155,7 @@ export class BalancesEndowedEvent {
    *  An account was created with some free balance.
    */
   get isV1050(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '1b1c107d9931735af253054e543179401a9ff7b0beaee7fa7aa61319dc40a290'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -170,7 +170,7 @@ export class BalancesEndowedEvent {
    * An account was created with some free balance.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '089e94580955109582764033c0ac689ca378b9d2d399441102b094e72be986e7'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '75951f685df19cbb5fdda09cf928a105518ceca9576d95bd18d4fac8802730ca'
   }
 
   /**
@@ -202,7 +202,7 @@ export class BalancesReserveRepatriatedEvent {
    *  Final argument indicates the destination balance type.
    */
   get isV2008(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '823db0df51a00ee6479e9d206981c4cb7b4afcdfb66f2b1626a9c053026a511e'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '68e9ec5664c8ffe977da0c890bac43122a5cf13565c1c936e2120ba4980bcf31'
   }
 
   /**
@@ -219,7 +219,7 @@ export class BalancesReserveRepatriatedEvent {
    * Final argument indicates the destination balance type.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '1dac0fc1bd585ad6dd890e892bed23d70ca0545bf18fa96b4ce0ba7f3ffcdbd1'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '6232d50d422cea3a6fd21da36387df36d1d366405d0c589566c6de85c9cf541f'
   }
 
   /**
@@ -251,7 +251,7 @@ export class BalancesReservedEvent {
    *  Some balance was reserved (moved from free to reserved).
    */
   get isV2008(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'c595c2f71b423f0c1e0798ad69320278f19e727a480f58f312a585980145cf22'
+    return this.ctx._chain.getEventHash('balances.Reserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -266,7 +266,7 @@ export class BalancesReservedEvent {
    * Some balance was reserved (moved from free to reserved).
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'bc321147cc9b824c85c432ac3c753b1319c9ad37babdd0e09ae0f99aeecc9360'
+    return this.ctx._chain.getEventHash('balances.Reserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -298,7 +298,7 @@ export class BalancesSlashedEvent {
    * amount_slashed\]
    */
   get isV9122(): boolean {
-    return this.ctx._chain.getEventHash('balances.Slashed') === '2483fc82edb5fdb0ff716405ceadec93041e61656d52a5eccaa1ae00b97e532b'
+    return this.ctx._chain.getEventHash('balances.Slashed') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -314,7 +314,7 @@ export class BalancesSlashedEvent {
    * Some amount was removed from the account (e.g. for misbehavior).
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Slashed') === '087119b0d937e152a3831b84db573c85f89c84a6fd587673ee923c9f0061ed66'
+    return this.ctx._chain.getEventHash('balances.Slashed') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -345,7 +345,7 @@ export class BalancesTransferEvent {
    *  Transfer succeeded (from, to, value, fees).
    */
   get isV1020(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '154fca303841d334782de2e871e3572f786f81f86e2a6153c2b9e8dc6fc27422'
+    return this.ctx._chain.getEventHash('balances.Transfer') === '72e6f0d399a72f77551d560f52df25d757e0643d0192b3bc837cbd91b6f36b27'
   }
 
   /**
@@ -360,7 +360,7 @@ export class BalancesTransferEvent {
    *  Transfer succeeded (from, to, value).
    */
   get isV1050(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '9611bd6b933331f197e8fa73bac36184681838292120987fec97092ae037d1c8'
+    return this.ctx._chain.getEventHash('balances.Transfer') === 'dad2bcdca357505fa3c7832085d0db53ce6f902bd9f5b52823ee8791d351872c'
   }
 
   /**
@@ -375,7 +375,7 @@ export class BalancesTransferEvent {
    * Transfer succeeded.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '99bc4786247456e0d4a44373efe405e598bfadfac87a7c41b0a82a91296836c1'
+    return this.ctx._chain.getEventHash('balances.Transfer') === '0ffdf35c495114c2d42a8bf6c241483fd5334ca0198662e14480ad040f1e3a66'
   }
 
   /**
@@ -406,7 +406,7 @@ export class BalancesUnreservedEvent {
    *  Some balance was unreserved (moved from reserved to free).
    */
   get isV2008(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'ab01310b8e7de989b74305e42be550e888c6563ed4ea284f7c56ae7d79566f8c'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -421,7 +421,7 @@ export class BalancesUnreservedEvent {
    * Some balance was unreserved (moved from reserved to free).
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'be12b7473ab82e15891b929b20269451c731ffad981836a76ca0aae115b9e9f6'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -452,7 +452,7 @@ export class BalancesWithdrawEvent {
    * Some amount was withdrawn from the account (e.g. for transaction fees). \[who, value\]
    */
   get isV9122(): boolean {
-    return this.ctx._chain.getEventHash('balances.Withdraw') === 'c817a046dc9663596372188650f4e0b0897f9149bbc73435595dee84b7a9b049'
+    return this.ctx._chain.getEventHash('balances.Withdraw') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -467,7 +467,7 @@ export class BalancesWithdrawEvent {
    * Some amount was withdrawn from the account (e.g. for transaction fees).
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('balances.Withdraw') === '7d47465a5bcac497a2c0e813fe27069aff5d6086a74365c4f40bc0d5332e1356'
+    return this.ctx._chain.getEventHash('balances.Withdraw') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -498,7 +498,7 @@ export class TreasuryDepositEvent {
    *  Some funds have been deposited.
    */
   get isV1020(): boolean {
-    return this.ctx._chain.getEventHash('treasury.Deposit') === '00a6b2996298e567aad20092952a8a74feec74cde3e7a57572700c49512f941d'
+    return this.ctx._chain.getEventHash('treasury.Deposit') === '47b59f698451e50cce59979f0121e842fa3f8b2bcef2e388222dbd69849514f9'
   }
 
   /**
@@ -509,13 +509,28 @@ export class TreasuryDepositEvent {
     return this.ctx._chain.decodeEvent(this.ctx.event)
   }
 
-  get isLatest(): boolean {
-    deprecateLatest()
-    return this.isV1020
+  /**
+   * Some funds have been deposited.
+   */
+  get isV9160(): boolean {
+    return this.ctx._chain.getEventHash('treasury.Deposit') === 'd74027ad27459f17d7446fef449271d1b0dc12b852c175623e871d009a661493'
   }
 
-  get asLatest(): bigint {
+  /**
+   * Some funds have been deposited.
+   */
+  get asV9160(): {value: bigint} {
+    assert(this.isV9160)
+    return this.ctx._chain.decodeEvent(this.ctx.event)
+  }
+
+  get isLatest(): boolean {
     deprecateLatest()
-    return this.asV1020
+    return this.isV9160
+  }
+
+  get asLatest(): {value: bigint} {
+    deprecateLatest()
+    return this.asV9160
   }
 }

--- a/prawns/balances/src/types/polkadot/events.ts
+++ b/prawns/balances/src/types/polkadot/events.ts
@@ -13,7 +13,7 @@ export class BalancesBalanceSetEvent {
    *  A balance was set by root (who, free, reserved).
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '890be9c0740650f86b325a08fc07ecc4c2b4f58212c6edaca87dabdbb64d3db1'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '0f263bfdefa394edfb38d20d33662423a2e0902235b599f9b2b0292f157f0902'
   }
 
   /**
@@ -28,7 +28,7 @@ export class BalancesBalanceSetEvent {
    * A balance was set by root.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.BalanceSet') === '4ab45d6d95726adfeb725535bf55a2406d3b4d8ae14ac9005c7bd7e07ea76fcc'
+    return this.ctx._chain.getEventHash('balances.BalanceSet') === '1e2b5d5a07046e6d6e5507661d3f3feaddfb41fc609a2336b24957322080ca77'
   }
 
   /**
@@ -59,7 +59,7 @@ export class BalancesDepositEvent {
    *  Some amount was deposited (e.g. for transaction fees).
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === 'cf0c633b4d95aa1626767eef7c869b6d51b4e864772aceeb18ec2d4ebd8a9101'
+    return this.ctx._chain.getEventHash('balances.Deposit') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -74,7 +74,7 @@ export class BalancesDepositEvent {
    * Some amount was deposited (e.g. for transaction fees).
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Deposit') === '3e10f037979c6bc49d783be86e7fa6eb9642f270ffedf3352fae03a41fcf22e4'
+    return this.ctx._chain.getEventHash('balances.Deposit') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -106,7 +106,7 @@ export class BalancesDustLostEvent {
    *  resulting in an outright loss.
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === 'cc03bf0e885d06ab5165f4598e72250fd3e16bc5ba4dbb099deae1a97e4bef09'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -123,7 +123,7 @@ export class BalancesDustLostEvent {
    * resulting in an outright loss.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.DustLost') === '10bbf3b0d3ec83ccf1a23f056e1a60d4f66be59072296b48ebf9172ffcdab3f6'
+    return this.ctx._chain.getEventHash('balances.DustLost') === '504f155afb2789c50df19d1f747fb2dc0e99bf8b7623c30bdb5cf82029fec760'
   }
 
   /**
@@ -155,7 +155,7 @@ export class BalancesEndowedEvent {
    *  An account was created with some free balance.
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '1b1c107d9931735af253054e543179401a9ff7b0beaee7fa7aa61319dc40a290'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -170,7 +170,7 @@ export class BalancesEndowedEvent {
    * An account was created with some free balance.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Endowed') === '089e94580955109582764033c0ac689ca378b9d2d399441102b094e72be986e7'
+    return this.ctx._chain.getEventHash('balances.Endowed') === '75951f685df19cbb5fdda09cf928a105518ceca9576d95bd18d4fac8802730ca'
   }
 
   /**
@@ -202,7 +202,7 @@ export class BalancesReserveRepatriatedEvent {
    *  Final argument indicates the destination balance type.
    */
   get isV8(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '823db0df51a00ee6479e9d206981c4cb7b4afcdfb66f2b1626a9c053026a511e'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '68e9ec5664c8ffe977da0c890bac43122a5cf13565c1c936e2120ba4980bcf31'
   }
 
   /**
@@ -219,7 +219,7 @@ export class BalancesReserveRepatriatedEvent {
    * Final argument indicates the destination balance type.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '1dac0fc1bd585ad6dd890e892bed23d70ca0545bf18fa96b4ce0ba7f3ffcdbd1'
+    return this.ctx._chain.getEventHash('balances.ReserveRepatriated') === '6232d50d422cea3a6fd21da36387df36d1d366405d0c589566c6de85c9cf541f'
   }
 
   /**
@@ -251,7 +251,7 @@ export class BalancesReservedEvent {
    *  Some balance was reserved (moved from free to reserved).
    */
   get isV8(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'c595c2f71b423f0c1e0798ad69320278f19e727a480f58f312a585980145cf22'
+    return this.ctx._chain.getEventHash('balances.Reserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -266,7 +266,7 @@ export class BalancesReservedEvent {
    * Some balance was reserved (moved from free to reserved).
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Reserved') === 'bc321147cc9b824c85c432ac3c753b1319c9ad37babdd0e09ae0f99aeecc9360'
+    return this.ctx._chain.getEventHash('balances.Reserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -298,7 +298,7 @@ export class BalancesSlashedEvent {
    * amount_slashed\]
    */
   get isV9122(): boolean {
-    return this.ctx._chain.getEventHash('balances.Slashed') === '2483fc82edb5fdb0ff716405ceadec93041e61656d52a5eccaa1ae00b97e532b'
+    return this.ctx._chain.getEventHash('balances.Slashed') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -314,7 +314,7 @@ export class BalancesSlashedEvent {
    * Some amount was removed from the account (e.g. for misbehavior).
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Slashed') === '087119b0d937e152a3831b84db573c85f89c84a6fd587673ee923c9f0061ed66'
+    return this.ctx._chain.getEventHash('balances.Slashed') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -345,7 +345,7 @@ export class BalancesTransferEvent {
    *  Transfer succeeded (from, to, value).
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '9611bd6b933331f197e8fa73bac36184681838292120987fec97092ae037d1c8'
+    return this.ctx._chain.getEventHash('balances.Transfer') === 'dad2bcdca357505fa3c7832085d0db53ce6f902bd9f5b52823ee8791d351872c'
   }
 
   /**
@@ -360,7 +360,7 @@ export class BalancesTransferEvent {
    * Transfer succeeded.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Transfer') === '99bc4786247456e0d4a44373efe405e598bfadfac87a7c41b0a82a91296836c1'
+    return this.ctx._chain.getEventHash('balances.Transfer') === '0ffdf35c495114c2d42a8bf6c241483fd5334ca0198662e14480ad040f1e3a66'
   }
 
   /**
@@ -391,7 +391,7 @@ export class BalancesUnreservedEvent {
    *  Some balance was unreserved (moved from reserved to free).
    */
   get isV8(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'ab01310b8e7de989b74305e42be550e888c6563ed4ea284f7c56ae7d79566f8c'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -406,7 +406,7 @@ export class BalancesUnreservedEvent {
    * Some balance was unreserved (moved from reserved to free).
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Unreserved') === 'be12b7473ab82e15891b929b20269451c731ffad981836a76ca0aae115b9e9f6'
+    return this.ctx._chain.getEventHash('balances.Unreserved') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -437,7 +437,7 @@ export class BalancesWithdrawEvent {
    * Some amount was withdrawn from the account (e.g. for transaction fees). \[who, value\]
    */
   get isV9122(): boolean {
-    return this.ctx._chain.getEventHash('balances.Withdraw') === 'c817a046dc9663596372188650f4e0b0897f9149bbc73435595dee84b7a9b049'
+    return this.ctx._chain.getEventHash('balances.Withdraw') === '23bebce4ca9ed37548947d07d4dc50e772f07401b9a416b6aa2f3e9cb5adcaf4'
   }
 
   /**
@@ -452,7 +452,7 @@ export class BalancesWithdrawEvent {
    * Some amount was withdrawn from the account (e.g. for transaction fees).
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('balances.Withdraw') === '7d47465a5bcac497a2c0e813fe27069aff5d6086a74365c4f40bc0d5332e1356'
+    return this.ctx._chain.getEventHash('balances.Withdraw') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
   }
 
   /**
@@ -483,7 +483,7 @@ export class TreasuryDepositEvent {
    *  Some funds have been deposited.
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('treasury.Deposit') === '00a6b2996298e567aad20092952a8a74feec74cde3e7a57572700c49512f941d'
+    return this.ctx._chain.getEventHash('treasury.Deposit') === '47b59f698451e50cce59979f0121e842fa3f8b2bcef2e388222dbd69849514f9'
   }
 
   /**
@@ -494,13 +494,28 @@ export class TreasuryDepositEvent {
     return this.ctx._chain.decodeEvent(this.ctx.event)
   }
 
-  get isLatest(): boolean {
-    deprecateLatest()
-    return this.isV0
+  /**
+   * Some funds have been deposited.
+   */
+  get isV9170(): boolean {
+    return this.ctx._chain.getEventHash('treasury.Deposit') === 'd74027ad27459f17d7446fef449271d1b0dc12b852c175623e871d009a661493'
   }
 
-  get asLatest(): bigint {
+  /**
+   * Some funds have been deposited.
+   */
+  get asV9170(): {value: bigint} {
+    assert(this.isV9170)
+    return this.ctx._chain.decodeEvent(this.ctx.event)
+  }
+
+  get isLatest(): boolean {
     deprecateLatest()
-    return this.asV0
+    return this.isV9170
+  }
+
+  get asLatest(): {value: bigint} {
+    deprecateLatest()
+    return this.asV9170
   }
 }

--- a/prawns/balances/yarn.lock
+++ b/prawns/balances/yarn.lock
@@ -789,14 +789,14 @@
   resolved "https://registry.yarnpkg.com/@subsquid/graphiql-console/-/graphiql-console-0.2.0.tgz#53edcc562342735e800361bb3892c54388b2e717"
   integrity sha512-Wh2Oxi9JkK79Y728yDEeY7JelcY1cGiQTbzVIRMFLT2tjkkoQ69goAGXdh9QmM/ANAVrHQkBUNJOLd5oAg//oQ==
 
-"@subsquid/graphql-server@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@subsquid/graphql-server/-/graphql-server-0.1.4.tgz#fe80ca860ef8ec29779189f7378ca5617e9028ad"
-  integrity sha512-RVWw+A9Z+vuzUNklSaZCGYOG+QpoRizoEHe9KYrKM7i0tJB6t5UQFk7L0CsyID3xRDmC7Kba5AWNskOhQHod4A==
+"@subsquid/graphql-server@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@subsquid/graphql-server/-/graphql-server-0.1.5.tgz#18f6cd6bc3ce0b9d165793f369e5f60cc2bbf113"
+  integrity sha512-LpHv1Q6vEFMtWJ7oRvrtBWLFuI53EXyk90UVnnp+s0pcEPNIk6apNCrw5igh8ABGz6kIFbqe37JA+r1HFnZiWw==
   dependencies:
     "@graphql-tools/merge" "^8"
     "@graphql-tools/utils" "^8"
-    "@subsquid/openreader" "^0.4.1"
+    "@subsquid/openreader" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     apollo-server-core "^3.6.2"
@@ -822,10 +822,26 @@
     graphql-parse-resolve-info "^4.12.0"
     pg "^8.7.1"
 
-"@subsquid/rpc-client@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.3.tgz#ccdf616d097f36854276fca1568007d0b8291966"
-  integrity sha512-ywMCBpvA1+351raEij1j5UPGwUMtPR4Yd1p5eZvWuRgl/oW3mxMOTwH3EORq3VQRY6AAwfQ/cFYmR022B1X6Ow==
+"@subsquid/openreader@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/openreader/-/openreader-0.5.0.tgz#fde0025786277af8e1d936c4b7cf5257bddf6677"
+  integrity sha512-Ve2dz8MWDZkPTuZWxXah5FEqpnvXxcjt0EHMgIjyh+I+8vZZF6a1fvWMXSDy34+YnIulFFNM8rC0q3zitMYVhQ==
+  dependencies:
+    "@graphql-tools/merge" "^8"
+    "@graphql-tools/utils" "^8"
+    "@subsquid/graphiql-console" "^0.2.0"
+    "@subsquid/util" "^0.0.4"
+    apollo-server-core "^3.6.2"
+    apollo-server-express "^3.6.2"
+    express "^4.17.2"
+    graphql "^15.8.0"
+    graphql-parse-resolve-info "^4.12.0"
+    pg "^8.7.1"
+
+"@subsquid/rpc-client@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.5.tgz#df42e6505b581d15ded3a90e60c1c0fde7fc3513"
+  integrity sha512-E97vV97Cu+xquhlPS7YqzcR8NK7sXApVvaVg027pAQWX48KeclJk3H42BxlJUDdzLhKl+ldP2xSmt4qGAlYYWQ==
   dependencies:
     websocket "^1.0.34"
 
@@ -844,14 +860,6 @@
   dependencies:
     "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/ss58-codec@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.0.3.tgz#facf1055772b83ed812fac9afd91d35d8a502085"
-  integrity sha512-H+fy+hkUOwbUeg+YhdxZSa4thY8Ffohg6kOpQP2NeBM1BbzRxERaUgd/IzzGUtMogLd9Go96NsSoHAnR6THxXw==
-  dependencies:
-    base-x "^3.0.9"
-    blake2b "^2.1.4"
-
 "@subsquid/ss58-codec@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.1.0.tgz#9c68b3da8b9dc05b3fd5ba12126f098f3ab82641"
@@ -860,29 +868,29 @@
     base-x "^3.0.9"
     blake2b "^2.1.4"
 
-"@subsquid/ss58@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.3.tgz#84ced011c54a08fb2cb2791f61a8fbecab84b94f"
-  integrity sha512-Zd2S22Yy48mqdCB4cNdSsr2+kW4a/amOAfYrrqMJYGx1sSO1M0as+d44dQcSOcj9UuOjUJ3N73f7wC4KGkkdCA==
+"@subsquid/ss58@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.4.tgz#9b6cb1f03be373ffa778ab12b3ede0e39fead55f"
+  integrity sha512-H1UEZYcJMG5yIBCUDA3PPA49KgcMuVecZdjqdnm04S5FWXcDFUbz3uMslFbXHeiMp2Qz2H3Lp2IJNp2d/8YHNg==
   dependencies:
-    "@subsquid/ss58-codec" "^0.0.3"
+    "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/substrate-metadata@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.3.0.tgz#7bc3e877f17a244ecb7a053057a7057e1c5b504d"
-  integrity sha512-wgAtvLBDfT4byIcKLwoaabi+LLcsUKAAv5a15wfc3eeHUrz58Autd7TguwfQiRXP0dFJsAviKxp6wKwalvu0kw==
+"@subsquid/substrate-metadata@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.5.0.tgz#447173eb8a133d7f6c15cbcdbb61c44bbafabd97"
+  integrity sha512-Td/1BYsn0M5VE0Gyyv5yDrjI9Hg8eJga+9A9SrksYwbpf6DK0lVja8AoXNkeNChgy/3o8zBnCZRnKRsLaSKXCg==
   dependencies:
     "@subsquid/scale-codec" "^0.3.1"
     "@subsquid/util" "^0.0.4"
 
-"@subsquid/substrate-processor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.3.0.tgz#0d83cf18b9b10db033e201f15f5b2a7c9f85a283"
-  integrity sha512-txXqb2zJ8agDbr9/4SIH5wB1HLn9N/dkxL2Og0IQyljz0uF7INT0Tvq6KAB4cPrw7k/we0e6BuwjtWVvk9gKjg==
+"@subsquid/substrate-processor@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.4.1.tgz#e74a08d1014fbcc42cc9916d84fd46a43e17e4f3"
+  integrity sha512-960Vnoc9XDXm8GntKjROSNlOt+uHVjk2Y7UdWzuREYVxJrW7Ce9w0F/6e3c1fco+dwCwDlECUPVOKpH/sUwDmQ==
   dependencies:
-    "@subsquid/rpc-client" "^0.1.3"
+    "@subsquid/rpc-client" "^0.1.5"
     "@subsquid/scale-codec-json" "^0.1.1"
-    "@subsquid/substrate-metadata" "^0.3.0"
+    "@subsquid/substrate-metadata" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     node-fetch "^2.6.7"

--- a/prawns/crowdloans/package.json
+++ b/prawns/crowdloans/package.json
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@polkadot/util-crypto": "^8.4.1",
-    "@subsquid/graphql-server": "^0.1.4",
-    "@subsquid/ss58": "^0.0.3",
-    "@subsquid/substrate-processor": "^0.3.0",
+    "@subsquid/graphql-server": "^0.1.5",
+    "@subsquid/ss58": "^0.0.4",
+    "@subsquid/substrate-processor": "^0.4.1",
     "dotenv": "^10.0.0",
     "pg": "^8.7.1",
     "typeorm": "^0.2.41"

--- a/prawns/crowdloans/src/types/kusama/events.ts
+++ b/prawns/crowdloans/src/types/kusama/events.ts
@@ -10,7 +10,7 @@ export class CrowdloanContributedEvent {
    *  Contributed to a crowd sale. [who, fund_index, amount]
    */
   get isV9010(): boolean {
-    return this.ctx._chain.getEventHash('crowdloan.Contributed') === 'd943dbc2818504a7c969bb6b64a01f7217f0321441ab3f4ec6efeed498414ca4'
+    return this.ctx._chain.getEventHash('crowdloan.Contributed') === 'ad00729b31f26d2879a6f96c1691ed42a69cd4947c75e84221a6bde93a3415bc'
   }
 
   /**

--- a/prawns/crowdloans/src/types/polkadot/events.ts
+++ b/prawns/crowdloans/src/types/polkadot/events.ts
@@ -11,7 +11,7 @@ export class CrowdloanContributedEvent {
    * Contributed to a crowd sale. `[who, fund_index, amount]`
    */
   get isV9110(): boolean {
-    return this.ctx._chain.getEventHash('crowdloan.Contributed') === 'd943dbc2818504a7c969bb6b64a01f7217f0321441ab3f4ec6efeed498414ca4'
+    return this.ctx._chain.getEventHash('crowdloan.Contributed') === 'ad00729b31f26d2879a6f96c1691ed42a69cd4947c75e84221a6bde93a3415bc'
   }
 
   /**

--- a/prawns/crowdloans/yarn.lock
+++ b/prawns/crowdloans/yarn.lock
@@ -789,14 +789,14 @@
   resolved "https://registry.yarnpkg.com/@subsquid/graphiql-console/-/graphiql-console-0.2.0.tgz#53edcc562342735e800361bb3892c54388b2e717"
   integrity sha512-Wh2Oxi9JkK79Y728yDEeY7JelcY1cGiQTbzVIRMFLT2tjkkoQ69goAGXdh9QmM/ANAVrHQkBUNJOLd5oAg//oQ==
 
-"@subsquid/graphql-server@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@subsquid/graphql-server/-/graphql-server-0.1.4.tgz#fe80ca860ef8ec29779189f7378ca5617e9028ad"
-  integrity sha512-RVWw+A9Z+vuzUNklSaZCGYOG+QpoRizoEHe9KYrKM7i0tJB6t5UQFk7L0CsyID3xRDmC7Kba5AWNskOhQHod4A==
+"@subsquid/graphql-server@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@subsquid/graphql-server/-/graphql-server-0.1.5.tgz#18f6cd6bc3ce0b9d165793f369e5f60cc2bbf113"
+  integrity sha512-LpHv1Q6vEFMtWJ7oRvrtBWLFuI53EXyk90UVnnp+s0pcEPNIk6apNCrw5igh8ABGz6kIFbqe37JA+r1HFnZiWw==
   dependencies:
     "@graphql-tools/merge" "^8"
     "@graphql-tools/utils" "^8"
-    "@subsquid/openreader" "^0.4.1"
+    "@subsquid/openreader" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     apollo-server-core "^3.6.2"
@@ -822,10 +822,26 @@
     graphql-parse-resolve-info "^4.12.0"
     pg "^8.7.1"
 
-"@subsquid/rpc-client@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.3.tgz#ccdf616d097f36854276fca1568007d0b8291966"
-  integrity sha512-ywMCBpvA1+351raEij1j5UPGwUMtPR4Yd1p5eZvWuRgl/oW3mxMOTwH3EORq3VQRY6AAwfQ/cFYmR022B1X6Ow==
+"@subsquid/openreader@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/openreader/-/openreader-0.5.0.tgz#fde0025786277af8e1d936c4b7cf5257bddf6677"
+  integrity sha512-Ve2dz8MWDZkPTuZWxXah5FEqpnvXxcjt0EHMgIjyh+I+8vZZF6a1fvWMXSDy34+YnIulFFNM8rC0q3zitMYVhQ==
+  dependencies:
+    "@graphql-tools/merge" "^8"
+    "@graphql-tools/utils" "^8"
+    "@subsquid/graphiql-console" "^0.2.0"
+    "@subsquid/util" "^0.0.4"
+    apollo-server-core "^3.6.2"
+    apollo-server-express "^3.6.2"
+    express "^4.17.2"
+    graphql "^15.8.0"
+    graphql-parse-resolve-info "^4.12.0"
+    pg "^8.7.1"
+
+"@subsquid/rpc-client@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.5.tgz#df42e6505b581d15ded3a90e60c1c0fde7fc3513"
+  integrity sha512-E97vV97Cu+xquhlPS7YqzcR8NK7sXApVvaVg027pAQWX48KeclJk3H42BxlJUDdzLhKl+ldP2xSmt4qGAlYYWQ==
   dependencies:
     websocket "^1.0.34"
 
@@ -844,14 +860,6 @@
   dependencies:
     "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/ss58-codec@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.0.3.tgz#facf1055772b83ed812fac9afd91d35d8a502085"
-  integrity sha512-H+fy+hkUOwbUeg+YhdxZSa4thY8Ffohg6kOpQP2NeBM1BbzRxERaUgd/IzzGUtMogLd9Go96NsSoHAnR6THxXw==
-  dependencies:
-    base-x "^3.0.9"
-    blake2b "^2.1.4"
-
 "@subsquid/ss58-codec@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.1.0.tgz#9c68b3da8b9dc05b3fd5ba12126f098f3ab82641"
@@ -860,29 +868,29 @@
     base-x "^3.0.9"
     blake2b "^2.1.4"
 
-"@subsquid/ss58@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.3.tgz#84ced011c54a08fb2cb2791f61a8fbecab84b94f"
-  integrity sha512-Zd2S22Yy48mqdCB4cNdSsr2+kW4a/amOAfYrrqMJYGx1sSO1M0as+d44dQcSOcj9UuOjUJ3N73f7wC4KGkkdCA==
+"@subsquid/ss58@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.4.tgz#9b6cb1f03be373ffa778ab12b3ede0e39fead55f"
+  integrity sha512-H1UEZYcJMG5yIBCUDA3PPA49KgcMuVecZdjqdnm04S5FWXcDFUbz3uMslFbXHeiMp2Qz2H3Lp2IJNp2d/8YHNg==
   dependencies:
-    "@subsquid/ss58-codec" "^0.0.3"
+    "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/substrate-metadata@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.3.0.tgz#7bc3e877f17a244ecb7a053057a7057e1c5b504d"
-  integrity sha512-wgAtvLBDfT4byIcKLwoaabi+LLcsUKAAv5a15wfc3eeHUrz58Autd7TguwfQiRXP0dFJsAviKxp6wKwalvu0kw==
+"@subsquid/substrate-metadata@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.5.0.tgz#447173eb8a133d7f6c15cbcdbb61c44bbafabd97"
+  integrity sha512-Td/1BYsn0M5VE0Gyyv5yDrjI9Hg8eJga+9A9SrksYwbpf6DK0lVja8AoXNkeNChgy/3o8zBnCZRnKRsLaSKXCg==
   dependencies:
     "@subsquid/scale-codec" "^0.3.1"
     "@subsquid/util" "^0.0.4"
 
-"@subsquid/substrate-processor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.3.0.tgz#0d83cf18b9b10db033e201f15f5b2a7c9f85a283"
-  integrity sha512-txXqb2zJ8agDbr9/4SIH5wB1HLn9N/dkxL2Og0IQyljz0uF7INT0Tvq6KAB4cPrw7k/we0e6BuwjtWVvk9gKjg==
+"@subsquid/substrate-processor@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.4.1.tgz#e74a08d1014fbcc42cc9916d84fd46a43e17e4f3"
+  integrity sha512-960Vnoc9XDXm8GntKjROSNlOt+uHVjk2Y7UdWzuREYVxJrW7Ce9w0F/6e3c1fco+dwCwDlECUPVOKpH/sUwDmQ==
   dependencies:
-    "@subsquid/rpc-client" "^0.1.3"
+    "@subsquid/rpc-client" "^0.1.5"
     "@subsquid/scale-codec-json" "^0.1.1"
-    "@subsquid/substrate-metadata" "^0.3.0"
+    "@subsquid/substrate-metadata" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     node-fetch "^2.6.7"

--- a/prawns/governance/package.json
+++ b/prawns/governance/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@polkadot/util-crypto": "^8.4.1",
     "@subsquid/graphql-server": "^0.1.4",
-    "@subsquid/ss58": "^0.0.3",
-    "@subsquid/substrate-processor": "^0.3.0",
+    "@subsquid/ss58": "^0.0.4",
+    "@subsquid/substrate-processor": "^0.4.1",
     "dotenv": "^10.0.0",
     "pg": "^8.7.1",
     "typeorm": "^0.2.41"

--- a/prawns/governance/src/types/khala/calls.ts
+++ b/prawns/governance/src/types/khala/calls.ts
@@ -25,7 +25,7 @@ export class CouncilVoteCall {
    *  # </weight>
    */
   get isV1(): boolean {
-    return this.ctx._chain.getCallHash('council.vote') === '89a6cc1af1492447ed05b72b49a416cd0bbde7d6f390ca281ad54d3e2e69c256'
+    return this.ctx._chain.getCallHash('council.vote') === 'f8a1069a57f7b721f47c086d08b6838ae1a0c08f58caddb82428ba5f1407540f'
   }
 
   /**
@@ -78,7 +78,7 @@ export class DemocracySecondCall {
    *  Weight: `O(S)` where S is the number of seconds a proposal already has.
    */
   get isV1(): boolean {
-    return this.ctx._chain.getCallHash('democracy.second') === 'c388fcd4c5b27ad8d3d1c706339f03968568c8a0f44b0114f86f00e55195abec'
+    return this.ctx._chain.getCallHash('democracy.second') === 'abe1357aae784eefd21f6999076deb6cfbc92fcb9e80c21e93a944ceb739423c'
   }
 
   /**
@@ -126,7 +126,7 @@ export class DemocracyVoteCall {
    *  Weight: `O(R)` where R is the number of referendums the voter has voted on.
    */
   get isV1(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '99c87c2462eae0050bd7a29171838d7c9d7b88f3bc9c600dc60b8d304a9c85dc'
+    return this.ctx._chain.getCallHash('democracy.vote') === '6cdb35b5ffcb74405cdf222b0cc0bf7ad7025d59f676bea6712d77bcc9aff1db'
   }
 
   /**
@@ -157,7 +157,7 @@ export class DemocracyVoteCall {
    * Weight: `O(R)` where R is the number of referendums the voter has voted on.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '0efe1fcbb98d2fc487ae2000c67d643ca2393fcf25703010de5a67225e5a4ecd'
+    return this.ctx._chain.getCallHash('democracy.vote') === '3936a4cb49f77280bd94142d4ec458afcf5cb8a5e5b0d602b1b1530928021e28'
   }
 
   /**
@@ -218,7 +218,7 @@ export class PhragmenElectionVoteCall {
    *  # </weight>
    */
   get isV14(): boolean {
-    return this.ctx._chain.getCallHash('phragmenElection.vote') === '1a1617701094b9706e12a855778e01f118c46b5ff80b1e2424a9c502ecb58c2c'
+    return this.ctx._chain.getCallHash('phragmenElection.vote') === '75939c25de1c96145b5d2d4bc8627a3fc22299f0e1f1f6f0709e54e884796bda'
   }
 
   /**

--- a/prawns/governance/src/types/khala/events.ts
+++ b/prawns/governance/src/types/khala/events.ts
@@ -12,7 +12,7 @@ export class DemocracyProposedEvent {
    *  A motion has been proposed by a public account. \[proposal_index, deposit\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === 'ec9d8411ccb58c13acecb12c4b4103b429f06983b49e7443b80c83975cb484ed'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === 'a0e51e81445baa317309351746e010ed2435e30ff7e53fbb2cf59283f3b9c536'
   }
 
   /**
@@ -27,7 +27,7 @@ export class DemocracyProposedEvent {
    * A motion has been proposed by a public account.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === '52a3fc64bce50a0f796295d5997106abe75022e8260b5b12503c89b205774e0d'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === '02ae149915d453560f4d12074a380744b3bbb2fe4c235e963f440e2d79243477'
   }
 
   /**
@@ -58,7 +58,7 @@ export class DemocracyStartedEvent {
    *  A referendum has begun. \[ref_index, threshold\]
    */
   get isV1(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '8d2e3ee24efda41975164e8978c8d4bd4db323c948fca6fc2185f7dbd5187279'
+    return this.ctx._chain.getEventHash('democracy.Started') === '31dcae10175d30392db6fc8a872e963baae4bcf3ee28dfd38b1653a0751c031f'
   }
 
   /**
@@ -73,7 +73,7 @@ export class DemocracyStartedEvent {
    * A referendum has begun.
    */
   get isV1090(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '7eddfd695fafebc9154f63d976aa98302dc7e2a7f64342b386cb0ddf84367abd'
+    return this.ctx._chain.getEventHash('democracy.Started') === '663653944bacc0e562b015a412877b12c32bc62814b673192c550438bf618ab4'
   }
 
   /**

--- a/prawns/governance/src/types/kusama/calls.ts
+++ b/prawns/governance/src/types/kusama/calls.ts
@@ -15,7 +15,7 @@ export class CouncilVoteCall {
    *  # </weight>
    */
   get isV1020(): boolean {
-    return this.ctx._chain.getCallHash('council.vote') === '89a6cc1af1492447ed05b72b49a416cd0bbde7d6f390ca281ad54d3e2e69c256'
+    return this.ctx._chain.getCallHash('council.vote') === 'f8a1069a57f7b721f47c086d08b6838ae1a0c08f58caddb82428ba5f1407540f'
   }
 
   /**
@@ -54,7 +54,7 @@ export class DemocracySecondCall {
    *  # </weight>
    */
   get isV1020(): boolean {
-    return this.ctx._chain.getCallHash('democracy.second') === '08bdd38fdfd3cf389b5bbb7db437ab7bbebac3e976758cf788257ec2b37ca6d8'
+    return this.ctx._chain.getCallHash('democracy.second') === '7ac80a800d6686f21181e7b5b45c8949dc5b807bc6ec111188c7c6850a21b898'
   }
 
   /**
@@ -89,7 +89,7 @@ export class DemocracySecondCall {
    *  # </weight>
    */
   get isV2005(): boolean {
-    return this.ctx._chain.getCallHash('democracy.second') === 'c388fcd4c5b27ad8d3d1c706339f03968568c8a0f44b0114f86f00e55195abec'
+    return this.ctx._chain.getCallHash('democracy.second') === 'abe1357aae784eefd21f6999076deb6cfbc92fcb9e80c21e93a944ceb739423c'
   }
 
   /**
@@ -141,7 +141,7 @@ export class DemocracyVoteCall {
    *  # </weight>
    */
   get isV1020(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '3a257842e5409d1ef798e72ec85e594b5abcb8e5073d74d987db05365764b7a0'
+    return this.ctx._chain.getCallHash('democracy.vote') === '3a01fd8d5e95145a311b99cf21decce5be8578650f311f3a6091395407f5efe9'
   }
 
   /**
@@ -173,7 +173,7 @@ export class DemocracyVoteCall {
    *  # </weight>
    */
   get isV1055(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '99c87c2462eae0050bd7a29171838d7c9d7b88f3bc9c600dc60b8d304a9c85dc'
+    return this.ctx._chain.getCallHash('democracy.vote') === '6cdb35b5ffcb74405cdf222b0cc0bf7ad7025d59f676bea6712d77bcc9aff1db'
   }
 
   /**
@@ -207,7 +207,7 @@ export class DemocracyVoteCall {
    * Weight: `O(R)` where R is the number of referendums the voter has voted on.
    */
   get isV9111(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '0efe1fcbb98d2fc487ae2000c67d643ca2393fcf25703010de5a67225e5a4ecd'
+    return this.ctx._chain.getCallHash('democracy.vote') === '3936a4cb49f77280bd94142d4ec458afcf5cb8a5e5b0d602b1b1530928021e28'
   }
 
   /**
@@ -268,7 +268,7 @@ export class PhragmenElectionVoteCall {
    *  # </weight>
    */
   get isV9010(): boolean {
-    return this.ctx._chain.getCallHash('phragmenElection.vote') === '1a1617701094b9706e12a855778e01f118c46b5ff80b1e2424a9c502ecb58c2c'
+    return this.ctx._chain.getCallHash('phragmenElection.vote') === '75939c25de1c96145b5d2d4bc8627a3fc22299f0e1f1f6f0709e54e884796bda'
   }
 
   /**

--- a/prawns/governance/src/types/kusama/events.ts
+++ b/prawns/governance/src/types/kusama/events.ts
@@ -9,7 +9,7 @@ export class DemocracyProposedEvent {
   }
 
   get isV1020(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === 'ec9d8411ccb58c13acecb12c4b4103b429f06983b49e7443b80c83975cb484ed'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === 'a0e51e81445baa317309351746e010ed2435e30ff7e53fbb2cf59283f3b9c536'
   }
 
   get asV1020(): [number, bigint] {
@@ -21,7 +21,7 @@ export class DemocracyProposedEvent {
    * A motion has been proposed by a public account.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === '52a3fc64bce50a0f796295d5997106abe75022e8260b5b12503c89b205774e0d'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === '02ae149915d453560f4d12074a380744b3bbb2fe4c235e963f440e2d79243477'
   }
 
   /**
@@ -49,7 +49,7 @@ export class DemocracyStartedEvent {
   }
 
   get isV1020(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '8d2e3ee24efda41975164e8978c8d4bd4db323c948fca6fc2185f7dbd5187279'
+    return this.ctx._chain.getEventHash('democracy.Started') === '31dcae10175d30392db6fc8a872e963baae4bcf3ee28dfd38b1653a0751c031f'
   }
 
   get asV1020(): [number, v1020.VoteThreshold] {
@@ -61,7 +61,7 @@ export class DemocracyStartedEvent {
    * A referendum has begun.
    */
   get isV9130(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '7eddfd695fafebc9154f63d976aa98302dc7e2a7f64342b386cb0ddf84367abd'
+    return this.ctx._chain.getEventHash('democracy.Started') === '663653944bacc0e562b015a412877b12c32bc62814b673192c550438bf618ab4'
   }
 
   /**

--- a/prawns/governance/src/types/polkadot/calls.ts
+++ b/prawns/governance/src/types/polkadot/calls.ts
@@ -23,7 +23,7 @@ export class CouncilVoteCall {
    *  # </weight>
    */
   get isV0(): boolean {
-    return this.ctx._chain.getCallHash('council.vote') === '89a6cc1af1492447ed05b72b49a416cd0bbde7d6f390ca281ad54d3e2e69c256'
+    return this.ctx._chain.getCallHash('council.vote') === 'f8a1069a57f7b721f47c086d08b6838ae1a0c08f58caddb82428ba5f1407540f'
   }
 
   /**
@@ -80,7 +80,7 @@ export class DemocracySecondCall {
    *  # </weight>
    */
   get isV0(): boolean {
-    return this.ctx._chain.getCallHash('democracy.second') === 'c388fcd4c5b27ad8d3d1c706339f03968568c8a0f44b0114f86f00e55195abec'
+    return this.ctx._chain.getCallHash('democracy.second') === 'abe1357aae784eefd21f6999076deb6cfbc92fcb9e80c21e93a944ceb739423c'
   }
 
   /**
@@ -143,7 +143,7 @@ export class DemocracyVoteCall {
    *  # </weight>
    */
   get isV0(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '99c87c2462eae0050bd7a29171838d7c9d7b88f3bc9c600dc60b8d304a9c85dc'
+    return this.ctx._chain.getCallHash('democracy.vote') === '6cdb35b5ffcb74405cdf222b0cc0bf7ad7025d59f676bea6712d77bcc9aff1db'
   }
 
   /**
@@ -183,7 +183,7 @@ export class DemocracyVoteCall {
    * Weight: `O(R)` where R is the number of referendums the voter has voted on.
    */
   get isV9110(): boolean {
-    return this.ctx._chain.getCallHash('democracy.vote') === '0efe1fcbb98d2fc487ae2000c67d643ca2393fcf25703010de5a67225e5a4ecd'
+    return this.ctx._chain.getCallHash('democracy.vote') === '3936a4cb49f77280bd94142d4ec458afcf5cb8a5e5b0d602b1b1530928021e28'
   }
 
   /**
@@ -244,7 +244,7 @@ export class PhragmenElectionVoteCall {
    *  # </weight>
    */
   get isV9050(): boolean {
-    return this.ctx._chain.getCallHash('phragmenElection.vote') === '1a1617701094b9706e12a855778e01f118c46b5ff80b1e2424a9c502ecb58c2c'
+    return this.ctx._chain.getCallHash('phragmenElection.vote') === '75939c25de1c96145b5d2d4bc8627a3fc22299f0e1f1f6f0709e54e884796bda'
   }
 
   /**

--- a/prawns/governance/src/types/polkadot/events.ts
+++ b/prawns/governance/src/types/polkadot/events.ts
@@ -12,7 +12,7 @@ export class DemocracyProposedEvent {
    *  A motion has been proposed by a public account.
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === 'ec9d8411ccb58c13acecb12c4b4103b429f06983b49e7443b80c83975cb484ed'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === 'a0e51e81445baa317309351746e010ed2435e30ff7e53fbb2cf59283f3b9c536'
   }
 
   /**
@@ -27,7 +27,7 @@ export class DemocracyProposedEvent {
    * A motion has been proposed by a public account.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Proposed') === '52a3fc64bce50a0f796295d5997106abe75022e8260b5b12503c89b205774e0d'
+    return this.ctx._chain.getEventHash('democracy.Proposed') === '02ae149915d453560f4d12074a380744b3bbb2fe4c235e963f440e2d79243477'
   }
 
   /**
@@ -58,7 +58,7 @@ export class DemocracyStartedEvent {
    *  A referendum has begun.
    */
   get isV0(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '8d2e3ee24efda41975164e8978c8d4bd4db323c948fca6fc2185f7dbd5187279'
+    return this.ctx._chain.getEventHash('democracy.Started') === '31dcae10175d30392db6fc8a872e963baae4bcf3ee28dfd38b1653a0751c031f'
   }
 
   /**
@@ -73,7 +73,7 @@ export class DemocracyStartedEvent {
    * A referendum has begun.
    */
   get isV9140(): boolean {
-    return this.ctx._chain.getEventHash('democracy.Started') === '7eddfd695fafebc9154f63d976aa98302dc7e2a7f64342b386cb0ddf84367abd'
+    return this.ctx._chain.getEventHash('democracy.Started') === '663653944bacc0e562b015a412877b12c32bc62814b673192c550438bf618ab4'
   }
 
   /**

--- a/prawns/governance/yarn.lock
+++ b/prawns/governance/yarn.lock
@@ -822,10 +822,10 @@
     graphql-parse-resolve-info "^4.12.0"
     pg "^8.7.1"
 
-"@subsquid/rpc-client@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.3.tgz#ccdf616d097f36854276fca1568007d0b8291966"
-  integrity sha512-ywMCBpvA1+351raEij1j5UPGwUMtPR4Yd1p5eZvWuRgl/oW3mxMOTwH3EORq3VQRY6AAwfQ/cFYmR022B1X6Ow==
+"@subsquid/rpc-client@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.5.tgz#df42e6505b581d15ded3a90e60c1c0fde7fc3513"
+  integrity sha512-E97vV97Cu+xquhlPS7YqzcR8NK7sXApVvaVg027pAQWX48KeclJk3H42BxlJUDdzLhKl+ldP2xSmt4qGAlYYWQ==
   dependencies:
     websocket "^1.0.34"
 
@@ -844,14 +844,6 @@
   dependencies:
     "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/ss58-codec@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.0.3.tgz#facf1055772b83ed812fac9afd91d35d8a502085"
-  integrity sha512-H+fy+hkUOwbUeg+YhdxZSa4thY8Ffohg6kOpQP2NeBM1BbzRxERaUgd/IzzGUtMogLd9Go96NsSoHAnR6THxXw==
-  dependencies:
-    base-x "^3.0.9"
-    blake2b "^2.1.4"
-
 "@subsquid/ss58-codec@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.1.0.tgz#9c68b3da8b9dc05b3fd5ba12126f098f3ab82641"
@@ -860,29 +852,29 @@
     base-x "^3.0.9"
     blake2b "^2.1.4"
 
-"@subsquid/ss58@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.3.tgz#84ced011c54a08fb2cb2791f61a8fbecab84b94f"
-  integrity sha512-Zd2S22Yy48mqdCB4cNdSsr2+kW4a/amOAfYrrqMJYGx1sSO1M0as+d44dQcSOcj9UuOjUJ3N73f7wC4KGkkdCA==
+"@subsquid/ss58@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.4.tgz#9b6cb1f03be373ffa778ab12b3ede0e39fead55f"
+  integrity sha512-H1UEZYcJMG5yIBCUDA3PPA49KgcMuVecZdjqdnm04S5FWXcDFUbz3uMslFbXHeiMp2Qz2H3Lp2IJNp2d/8YHNg==
   dependencies:
-    "@subsquid/ss58-codec" "^0.0.3"
+    "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/substrate-metadata@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.3.0.tgz#7bc3e877f17a244ecb7a053057a7057e1c5b504d"
-  integrity sha512-wgAtvLBDfT4byIcKLwoaabi+LLcsUKAAv5a15wfc3eeHUrz58Autd7TguwfQiRXP0dFJsAviKxp6wKwalvu0kw==
+"@subsquid/substrate-metadata@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.5.0.tgz#447173eb8a133d7f6c15cbcdbb61c44bbafabd97"
+  integrity sha512-Td/1BYsn0M5VE0Gyyv5yDrjI9Hg8eJga+9A9SrksYwbpf6DK0lVja8AoXNkeNChgy/3o8zBnCZRnKRsLaSKXCg==
   dependencies:
     "@subsquid/scale-codec" "^0.3.1"
     "@subsquid/util" "^0.0.4"
 
-"@subsquid/substrate-processor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.3.0.tgz#0d83cf18b9b10db033e201f15f5b2a7c9f85a283"
-  integrity sha512-txXqb2zJ8agDbr9/4SIH5wB1HLn9N/dkxL2Og0IQyljz0uF7INT0Tvq6KAB4cPrw7k/we0e6BuwjtWVvk9gKjg==
+"@subsquid/substrate-processor@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.4.1.tgz#e74a08d1014fbcc42cc9916d84fd46a43e17e4f3"
+  integrity sha512-960Vnoc9XDXm8GntKjROSNlOt+uHVjk2Y7UdWzuREYVxJrW7Ce9w0F/6e3c1fco+dwCwDlECUPVOKpH/sUwDmQ==
   dependencies:
-    "@subsquid/rpc-client" "^0.1.3"
+    "@subsquid/rpc-client" "^0.1.5"
     "@subsquid/scale-codec-json" "^0.1.1"
-    "@subsquid/substrate-metadata" "^0.3.0"
+    "@subsquid/substrate-metadata" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     node-fetch "^2.6.7"

--- a/prawns/identities/package.json
+++ b/prawns/identities/package.json
@@ -20,15 +20,15 @@
   },
   "dependencies": {
     "@polkadot/util-crypto": "^8.4.1",
-    "@subsquid/graphql-server": "^0.1.4",
-    "@subsquid/ss58": "^0.0.3",
-    "@subsquid/substrate-processor": "^0.3.0",
+    "@subsquid/graphql-server": "^0.1.5",
+    "@subsquid/ss58": "^0.0.4",
+    "@subsquid/substrate-processor": "^0.4.1",
     "dotenv": "^10.0.0",
     "pg": "^8.7.1",
     "typeorm": "^0.2.41"
   },
   "devDependencies": {
-    "@subsquid/cli": "^0.1.1",
+    "@subsquid/cli": "^0.1.4",
     "@types/node": "^16.11.17",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "eslint": "7.26.0",

--- a/prawns/identities/yarn.lock
+++ b/prawns/identities/yarn.lock
@@ -761,7 +761,7 @@
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
   integrity sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==
 
-"@subsquid/cli@^0.1.1":
+"@subsquid/cli@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@subsquid/cli/-/cli-0.1.4.tgz#f41d3cb5d184431c5b01ce3c971eaa731f1d8cd9"
   integrity sha512-nA3/vkl8Fu7IrBWfEdRGKsug8XIPXRXYP1WDIQ5UuITtzOsUFgGKL5p/kNviEA+D4Uo95jM+YXhrTg+Xkc/Y6g==
@@ -789,7 +789,7 @@
   resolved "https://registry.yarnpkg.com/@subsquid/graphiql-console/-/graphiql-console-0.2.0.tgz#53edcc562342735e800361bb3892c54388b2e717"
   integrity sha512-Wh2Oxi9JkK79Y728yDEeY7JelcY1cGiQTbzVIRMFLT2tjkkoQ69goAGXdh9QmM/ANAVrHQkBUNJOLd5oAg//oQ==
 
-"@subsquid/graphql-server@^0.1.4":
+"@subsquid/graphql-server@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@subsquid/graphql-server/-/graphql-server-0.1.5.tgz#18f6cd6bc3ce0b9d165793f369e5f60cc2bbf113"
   integrity sha512-LpHv1Q6vEFMtWJ7oRvrtBWLFuI53EXyk90UVnnp+s0pcEPNIk6apNCrw5igh8ABGz6kIFbqe37JA+r1HFnZiWw==
@@ -822,7 +822,7 @@
     graphql-parse-resolve-info "^4.12.0"
     pg "^8.7.1"
 
-"@subsquid/rpc-client@^0.1.3":
+"@subsquid/rpc-client@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@subsquid/rpc-client/-/rpc-client-0.1.5.tgz#df42e6505b581d15ded3a90e60c1c0fde7fc3513"
   integrity sha512-E97vV97Cu+xquhlPS7YqzcR8NK7sXApVvaVg027pAQWX48KeclJk3H42BxlJUDdzLhKl+ldP2xSmt4qGAlYYWQ==
@@ -844,14 +844,6 @@
   dependencies:
     "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/ss58-codec@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.0.3.tgz#facf1055772b83ed812fac9afd91d35d8a502085"
-  integrity sha512-H+fy+hkUOwbUeg+YhdxZSa4thY8Ffohg6kOpQP2NeBM1BbzRxERaUgd/IzzGUtMogLd9Go96NsSoHAnR6THxXw==
-  dependencies:
-    base-x "^3.0.9"
-    blake2b "^2.1.4"
-
 "@subsquid/ss58-codec@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@subsquid/ss58-codec/-/ss58-codec-0.1.0.tgz#9c68b3da8b9dc05b3fd5ba12126f098f3ab82641"
@@ -860,29 +852,29 @@
     base-x "^3.0.9"
     blake2b "^2.1.4"
 
-"@subsquid/ss58@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.3.tgz#84ced011c54a08fb2cb2791f61a8fbecab84b94f"
-  integrity sha512-Zd2S22Yy48mqdCB4cNdSsr2+kW4a/amOAfYrrqMJYGx1sSO1M0as+d44dQcSOcj9UuOjUJ3N73f7wC4KGkkdCA==
+"@subsquid/ss58@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@subsquid/ss58/-/ss58-0.0.4.tgz#9b6cb1f03be373ffa778ab12b3ede0e39fead55f"
+  integrity sha512-H1UEZYcJMG5yIBCUDA3PPA49KgcMuVecZdjqdnm04S5FWXcDFUbz3uMslFbXHeiMp2Qz2H3Lp2IJNp2d/8YHNg==
   dependencies:
-    "@subsquid/ss58-codec" "^0.0.3"
+    "@subsquid/ss58-codec" "^0.1.0"
 
-"@subsquid/substrate-metadata@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.3.1.tgz#3a37908baa6559e6ed57b6be5dd11e460b733b28"
-  integrity sha512-VbTK1P/AM70o8L5dBOjx0CHMmLOmgOnK1JlB0AeISf0fzizTAFLaqLwG3juyt6MmChwbsMyGGX45zyE/wHF9pw==
+"@subsquid/substrate-metadata@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-metadata/-/substrate-metadata-0.5.0.tgz#447173eb8a133d7f6c15cbcdbb61c44bbafabd97"
+  integrity sha512-Td/1BYsn0M5VE0Gyyv5yDrjI9Hg8eJga+9A9SrksYwbpf6DK0lVja8AoXNkeNChgy/3o8zBnCZRnKRsLaSKXCg==
   dependencies:
     "@subsquid/scale-codec" "^0.3.1"
     "@subsquid/util" "^0.0.4"
 
-"@subsquid/substrate-processor@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.3.0.tgz#0d83cf18b9b10db033e201f15f5b2a7c9f85a283"
-  integrity sha512-txXqb2zJ8agDbr9/4SIH5wB1HLn9N/dkxL2Og0IQyljz0uF7INT0Tvq6KAB4cPrw7k/we0e6BuwjtWVvk9gKjg==
+"@subsquid/substrate-processor@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@subsquid/substrate-processor/-/substrate-processor-0.4.1.tgz#e74a08d1014fbcc42cc9916d84fd46a43e17e4f3"
+  integrity sha512-960Vnoc9XDXm8GntKjROSNlOt+uHVjk2Y7UdWzuREYVxJrW7Ce9w0F/6e3c1fco+dwCwDlECUPVOKpH/sUwDmQ==
   dependencies:
-    "@subsquid/rpc-client" "^0.1.3"
+    "@subsquid/rpc-client" "^0.1.5"
     "@subsquid/scale-codec-json" "^0.1.1"
-    "@subsquid/substrate-metadata" "^0.3.0"
+    "@subsquid/substrate-metadata" "^0.5.0"
     "@subsquid/typeorm-config" "^0.0.4"
     "@subsquid/util" "^0.0.4"
     node-fetch "^2.6.7"


### PR DESCRIPTION
This PR fixes discrepancies between event/call hashes in typegen classes and runtime.

Note, that `Error: Unknown variant raw` for `identities.set_identity` call is unfixable until release of a new archive. 
Please, use raw json for this call for now.