### PR TITLE
Fix: Tips Indexer: Add support to decode the params from the multisig calls 

### DIFF
--- a/prawns/tips/src/handlers/tips.tips_new.event.ts
+++ b/prawns/tips/src/handlers/tips.tips_new.event.ts
@@ -10,6 +10,12 @@ import { decodeAddress } from '../utils';
 import getApi from '../utils/getApi';
 import { getTipsNewTipEvent } from './typeGetters/getTipsTipNewEvent';
 
+interface TipCallArgs {
+  who: string,
+  reason: string,
+  tipValue: bigint | null,
+}
+
 export default (network: SubstrateNetwork) =>
   async (ctx: EventHandlerContext) => {
     if (!ctx.extrinsic) {
@@ -48,11 +54,7 @@ export default (network: SubstrateNetwork) =>
     await ctx.store.save(tipModel);
   };
 
-function getMultiSigCallArgs(ctx: EventHandlerContext, proxyCallArgs: any): {
-  who: string,
-  reason: string,
-  tipValue: bigint | null,
-} {
+function getMultiSigCallArgs(ctx: EventHandlerContext, proxyCallArgs: any): TipCallArgs {
   const c = new Codec(ctx._chain.description.types);
   const data = c.decodeBinary(ctx._chain.description.call, proxyCallArgs);
 
@@ -71,11 +73,7 @@ function getMultiSigCallArgs(ctx: EventHandlerContext, proxyCallArgs: any): {
   };
 }
 
-function getArgsFromCall(ctx: EventHandlerContext, extrinsic: SubstrateExtrinsic, proxyCallArgs: any): {
-  who: string,
-  reason: string,
-  tipValue: bigint | null,
-} {
+function getArgsFromCall(ctx: EventHandlerContext, extrinsic: SubstrateExtrinsic, proxyCallArgs: any): TipCallArgs {
   if (extrinsic.method === 'asMulti') {
     return getMultiSigCallArgs(ctx, proxyCallArgs);
   }

--- a/prawns/tips/src/handlers/tips.tips_new.event.ts
+++ b/prawns/tips/src/handlers/tips.tips_new.event.ts
@@ -2,7 +2,8 @@ import { ApiDecoration } from '@polkadot/api/types';
 import type { Balance, OpenTipTo225 } from '@polkadot/types/interfaces';
 import type { PalletTipsOpenTip } from '@polkadot/types/lookup';
 import { hexToString, u8aToHex } from '@polkadot/util';
-import { EventHandlerContext, ExtrinsicArg } from '@subsquid/substrate-processor';
+import { Codec } from '@subsquid/scale-codec';
+import { EventHandlerContext, ExtrinsicArg, SubstrateExtrinsic } from '@subsquid/substrate-processor';
 import { SubstrateNetwork, SubstrateTip } from '../model';
 import { SubstrateTipStatus } from '../model/generated/_substrateTipStatus';
 import { decodeAddress } from '../utils';
@@ -12,17 +13,17 @@ import { getTipsNewTipEvent } from './typeGetters/getTipsTipNewEvent';
 export default (network: SubstrateNetwork) =>
   async (ctx: EventHandlerContext) => {
     if (!ctx.extrinsic) {
-      console.log(ctx.event);
       return;
     }
 
     const proxyCallArgs = getFieldFromExtrinsicArgs(ctx.extrinsic.args, 'call');
+    const args = getArgsFromCall(ctx, ctx.extrinsic, proxyCallArgs);
 
-    const [who, reason, tipValue] = [
-      proxyCallArgs ? proxyCallArgs.args.who : getFieldFromExtrinsicArgs(ctx.extrinsic.args, 'who') as string,
-      proxyCallArgs ? proxyCallArgs.args.reason : getFieldFromExtrinsicArgs(ctx.extrinsic.args, 'reason') as string,
-      proxyCallArgs ? proxyCallArgs.args.tipValue : getFieldFromExtrinsicArgs(ctx.extrinsic.args, 'tipValue') as bigint,
-    ];
+    if (!args) {
+      return;
+    }
+
+    const {who, reason, tipValue} = args;
 
     const newTipEvent = getTipsNewTipEvent(ctx, network);
     const blockNumber = BigInt(ctx.block.height);
@@ -46,12 +47,51 @@ export default (network: SubstrateNetwork) =>
       who: decodeAddress(who),
       finder: rootAccount,
       tipValue,
-      reason: hexToString(reason),
+      reason,
       deposit: (await getDeposit(apiAtBlock, newTipEvent.tipHash))?.toBigInt(),
     });
 
     await ctx.store.save(tipModel);
   };
+
+function getMultiSigCallArgs(ctx: EventHandlerContext, proxyCallArgs: any): {
+  who: string,
+  reason: string,
+  tipValue: bigint | null,
+} | null {
+  const c = new Codec(ctx._chain.description.types);
+  const data = c.decodeBinary(ctx._chain.description.call, proxyCallArgs);
+
+  const who = data.value.who ? '0x' + Buffer.from(data.value.who).toString('hex') : null;
+  const reason = data.value.reason ? Buffer.from(data.value.reason).toString() : null;
+  const tipValue = data.value.tipValue ? Buffer.from(data.value.tipValue).toString() : null;
+
+  if (!who || !reason) {
+    return null;
+  }
+
+  return {
+    who,
+    reason,
+    tipValue: tipValue ? BigInt(tipValue) : null,
+  };
+}
+
+function getArgsFromCall(ctx: EventHandlerContext, extrinsic: SubstrateExtrinsic, proxyCallArgs: any): {
+  who: string,
+  reason: string,
+  tipValue: bigint | null,
+} | null {
+  if (extrinsic.method === 'asMulti') {
+    return getMultiSigCallArgs(ctx, proxyCallArgs);
+  }
+
+  return {
+    who: proxyCallArgs ? proxyCallArgs.args.who : getFieldFromExtrinsicArgs(extrinsic.args, 'who') as string,
+    reason: hexToString(proxyCallArgs ? proxyCallArgs.args.reason : getFieldFromExtrinsicArgs(extrinsic.args, 'reason') as string),
+    tipValue: proxyCallArgs ? proxyCallArgs.args.tipValue : getFieldFromExtrinsicArgs(extrinsic.args, 'tipValue') as bigint,
+  };
+}
 
 function isCurrentTip(tip: PalletTipsOpenTip | OpenTipTo225): tip is PalletTipsOpenTip {
   return !!(tip as PalletTipsOpenTip)?.findersFee;
@@ -72,5 +112,3 @@ async function getDeposit(apiAtBlock: ApiDecoration<"promise">, hash: Uint8Array
 function getFieldFromExtrinsicArgs(args: ExtrinsicArg[], name: string): any {
   return (args.find(arg => arg.name === name))?.value;
 }
-
-


### PR DESCRIPTION
We need to use the Scale Codec to decode the binary of the call arguments.

After that, we _massage_ the needed arguments for the format we were getting in the other types of call.