### PR TITLE
Progress check with chain height and last block

### DIFF
--- a/cli/src/getProjectIndexingProgress.ts
+++ b/cli/src/getProjectIndexingProgress.ts
@@ -13,9 +13,13 @@ const getIndexingProcessorContainers = (projectName: string) => {
 
 export default async (projectName: string) => Promise.all(
   getIndexingProcessorContainers(projectName).map(async (container) => {
-    const progressString = (await axios.get(`http://${container.host}/metrics/sqd_processor_sync_ratio`)).data.toString();
-    const progressMatches = /([\d.]+)/g.exec(progressString) || [0];
-    const progress = Number(progressMatches[0]);
+    const chainHeight = (await axios.get(`http://${container.host}/metrics/sqd_processor_chain_height`)).data.toString();
+    const chainHeightMatches = /([\d.]+)/g.exec(chainHeight) || [0];
+
+    const lastBlock = (await axios.get(`http://${container.host}/metrics/sqd_processor_last_block`)).data.toString();
+    const lastBlockMatches = /([\d.]+)/g.exec(lastBlock) || [0];
+
+    const progress = Number(lastBlockMatches[0]) / Number(chainHeightMatches[0]);
 
     return { ...container, progress };
 }));


### PR DESCRIPTION
Seems that when there are no new blocks from the point where the snapshot was generated, the `sqd_processor_sync_ratio` doesn't really update.
What does update is the `sqd_processor_last_block` and `sqd_processor_chain_height`, which is what I propose for us to measure progress.


![Screenshot 2022-05-03 at 08 06 38](https://user-images.githubusercontent.com/2465005/166416173-3aa44a2c-0afd-4b80-9736-b76bce03c9ef.png)
